### PR TITLE
GCLoader update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 __pycache__
 build/
+dist/**
 entry/data/
 *.dol
 *.elf

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Flippyboot IPL
 
+This project provides a program called cubeboot which is able to play the GameCube
+boot animation. This is useful for some modchips like PicoBoot which skip the boot
+sequence. This project allows you to restore and customize the boot animation with
+custom colors and logos.
+
+## Technical Details
+
 This project is a patching framework for the GameCube IPL which is called BS2.
 The project was originally intended to restore the Boot Animation on Flippyboot.
 Now the project has been generalized and works on both Flippyboot and PicoBoot.

--- a/cubeboot/source/fatfs/ff.c
+++ b/cubeboot/source/fatfs/ff.c
@@ -23,7 +23,6 @@
 #include "ff.h"			/* Declarations of FatFs API */
 #include "diskio.h"		/* Declarations of device I/O functions */
 
-
 /*--------------------------------------------------------------------------
 
    Module Private Definitions
@@ -704,26 +703,26 @@ static int dbc_1st (BYTE c)
 }
 
 
-// /* Test if the byte is DBC 2nd byte */
-// static int dbc_2nd (BYTE c)
-// {
-// #if FF_CODE_PAGE == 0		/* Variable code page */
-// 	if (DbcTbl && c >= DbcTbl[4]) {
-// 		if (c <= DbcTbl[5]) return 1;					/* 2nd byte range 1 */
-// 		if (c >= DbcTbl[6] && c <= DbcTbl[7]) return 1;	/* 2nd byte range 2 */
-// 		if (c >= DbcTbl[8] && c <= DbcTbl[9]) return 1;	/* 2nd byte range 3 */
-// 	}
-// #elif FF_CODE_PAGE >= 900	/* DBCS fixed code page */
-// 	if (c >= DbcTbl[4]) {
-// 		if (c <= DbcTbl[5]) return 1;
-// 		if (c >= DbcTbl[6] && c <= DbcTbl[7]) return 1;
-// 		if (c >= DbcTbl[8] && c <= DbcTbl[9]) return 1;
-// 	}
-// #else						/* SBCS fixed code page */
-// 	if (c != 0) return 0;	/* Always false */
-// #endif
-// 	return 0;
-// }
+/* Test if the byte is DBC 2nd byte */
+static int dbc_2nd (BYTE c)
+{
+#if FF_CODE_PAGE == 0		/* Variable code page */
+	if (DbcTbl && c >= DbcTbl[4]) {
+		if (c <= DbcTbl[5]) return 1;					/* 2nd byte range 1 */
+		if (c >= DbcTbl[6] && c <= DbcTbl[7]) return 1;	/* 2nd byte range 2 */
+		if (c >= DbcTbl[8] && c <= DbcTbl[9]) return 1;	/* 2nd byte range 3 */
+	}
+#elif FF_CODE_PAGE >= 900	/* DBCS fixed code page */
+	if (c >= DbcTbl[4]) {
+		if (c <= DbcTbl[5]) return 1;
+		if (c >= DbcTbl[6] && c <= DbcTbl[7]) return 1;
+		if (c >= DbcTbl[8] && c <= DbcTbl[9]) return 1;
+	}
+#else						/* SBCS fixed code page */
+	if (c != 0) return 0;	/* Always false */
+#endif
+	return 0;
+}
 
 
 #if FF_USE_LFN

--- a/cubeboot/source/fatfs/ffconf.h
+++ b/cubeboot/source/fatfs/ffconf.h
@@ -15,7 +15,7 @@
 /  and optional writing functions as well. */
 
 
-#define FF_FS_MINIMIZE	3
+#define FF_FS_MINIMIZE	1
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: Basic functions are fully enabled.
@@ -47,7 +47,7 @@
 /  (0:Disable or 1:Enable) Also FF_FS_READONLY needs to be 0 to enable this option. */
 
 
-#define FF_USE_LABEL	1
+#define FF_USE_LABEL	0
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 

--- a/cubeboot/source/ipl.c
+++ b/cubeboot/source/ipl.c
@@ -18,6 +18,9 @@
 #include "crc32.h"
 #include "ipl.h"
 
+extern GXRModeObj *rmode;
+extern void *xfb;
+
 #define IPL_ROM_FONT_SJIS	0x1AFF00
 #define DECRYPT_START		0x100
 
@@ -52,9 +55,8 @@ static u8 *bs2 = (u8*)(BS2_BASE_ADDR);
 s8 bios_index = -1;
 bios_item *current_bios;
 
-
 #ifdef TEST_IPL_PATH
-char *bios_path = "/bios-sfn/ntsc11.bin";
+char *bios_path = "/bios/gc-ntsc-10.bin";
 #else
 char *bios_path = "/ipl.bin";
 #endif

--- a/cubeboot/source/ipl.c
+++ b/cubeboot/source/ipl.c
@@ -69,13 +69,13 @@ char *bios_path = "/ipl.bin";
 
 // NOTE: these are not ipl.bin CRCs, but decoded ipl[0x100:] hashes
 bios_item bios_table[] = {
-    {"gc-ntsc-10",      "ntsc10",       "VER_NTSC_10",      0xa8325e47}, // SDA = 81465320
-    {"gc-ntsc-11",      "ntsc11",       "VER_NTSC_11",      0xf1ebeb95}, // SDA = 81489120
-    {"gc-ntsc-12_001",  "ntsc12_001",   "VER_NTSC_12_001",  0xc4c5a12a}, // SDA = 8148b1c0
-    {"gc-ntsc-12_101",  "ntsc12_101",   "VER_NTSC_12_101",  0xbf225e4d}, // SDA = 8148b640
-    {"gc-pal-10",       "pal10",        "VER_PAL_10",       0x5c3445d0}, // SDA = 814b4fc0
-    {"gc-pal-11",       "pal11",        "VER_PAL_11",       0x05196b74}, // SDA = 81483de0
-    {"gc-pal-12",       "pal12",        "VER_PAL_12",       0x1082fbc9}, // SDA = 814b7280
+    {IPL_NTSC_10,      "gc-ntsc-10",      "ntsc10",       "VER_NTSC_10",      CRC(0xa8325e47), SDA(0x81465320)},
+    {IPL_NTSC_11,      "gc-ntsc-11",      "ntsc11",       "VER_NTSC_11",      CRC(0xf1ebeb95), SDA(0x81489120)},
+    {IPL_NTSC_12_001,  "gc-ntsc-12_001",  "ntsc12_001",   "VER_NTSC_12_001",  CRC(0xc4c5a12a), SDA(0x8148b1c0)},
+    {IPL_NTSC_12_101,  "gc-ntsc-12_101",  "ntsc12_101",   "VER_NTSC_12_101",  CRC(0xbf225e4d), SDA(0x8148b640)},
+    {IPL_PAL_10,       "gc-pal-10",       "pal10",        "VER_PAL_10",       CRC(0x5c3445d0), SDA(0x814b4fc0)},
+    {IPL_PAL_11,       "gc-pal-11",       "pal11",        "VER_PAL_11",       CRC(0x05196b74), SDA(0x81483de0)},
+    {IPL_PAL_12,       "gc-pal-12",       "pal12",        "VER_PAL_12",       CRC(0x1082fbc9), SDA(0x814b7280)},
 };
 
 extern void __SYS_ReadROM(void *buf,u32 len,u32 offset);

--- a/cubeboot/source/ipl.h
+++ b/cubeboot/source/ipl.h
@@ -1,11 +1,25 @@
 #include <gctypes.h>
 
+#define CRC(x) x
+#define SDA(x) x
+
+typedef enum ipl_version {
+    IPL_NTSC_10,
+    IPL_NTSC_11,
+    IPL_NTSC_12_001,
+    IPL_NTSC_12_101,
+    IPL_PAL_10,
+    IPL_PAL_11,
+    IPL_PAL_12,
+} ipl_version;
+
 typedef struct {
+    ipl_version version;
     char *name;
     char *reloc_prefix;
     char *patch_suffix;
     u32 crc;
-    // u32 sda;
+    u32 sda;
 } bios_item;
 
 extern bios_item *current_bios;

--- a/cubeboot/source/main.c
+++ b/cubeboot/source/main.c
@@ -181,6 +181,11 @@ int main() {
     // load ipl
     load_ipl();
 
+    // disable progressive on unsupported IPLs
+    if (current_bios->version == IPL_NTSC_10 || current_bios->version == IPL_PAL_10) {
+        settings.progressive_enabled = FALSE;
+    }
+
 //// elf world pt2
 
     // setup local vars

--- a/cubeboot/source/settings.c
+++ b/cubeboot/source/settings.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 
 #include "sd.h"
 #include "halt.h"
@@ -16,7 +17,7 @@ void load_settings() {
     int config_size = get_file_size("/cubeboot.ini");
     if (config_size == SD_FAIL) return;
 
-    void *config_buf = malloc(config_size + 1);
+    void *config_buf = memalign(32, config_size + 1);
     if (config_buf == NULL) {
         prog_halt("Could not allocate buffer for config file\n");
         return;

--- a/cubeboot/source/uff.c
+++ b/cubeboot/source/uff.c
@@ -21,6 +21,7 @@ static char *abs_path(char *path) {
 }
 
 FRESULT uf_mount(FATFS* fs) {
+    iprintf("Device ptr = %08x\n", (u32)get_current_device());
     if (!fatMountSimple("sd", get_current_device())) {
         return FR_DISK_ERR;
     }

--- a/patches/include/config.h
+++ b/patches/include/config.h
@@ -1,1 +1,1 @@
-// #define DEBUG
+#define DEBUG

--- a/patches/include/config.h
+++ b/patches/include/config.h
@@ -1,1 +1,1 @@
-#define DEBUG
+// #define DEBUG

--- a/patches/source/main.c
+++ b/patches/source/main.c
@@ -77,6 +77,7 @@ __attribute_used__ void mod_cube_colors() {
     rgb_color target_color;
     target_color.color = (cube_color << 8) | 0xFF;
 
+    // TODO: the HSL calculations do not render good results for darker inputs, I still need to tune SAT/LUM scaling
     // tough colors: 252850 A18594 763C28
 
     u32 target_hsl = GRRLIB_RGBToHSL(target_color.color);
@@ -229,6 +230,11 @@ __attribute_used__ void pre_main() {
 
         static u8 progressive_vfilter[7] = {0, 0, 21, 22, 21, 0, 0};
         memcpy(rmode->vfilter, progressive_vfilter, sizeof(progressive_vfilter));
+    }
+
+    // can't boot dol
+    if (!start_game) {
+        cube_color = 0x4A412A; // or 0x0000FF
     }
 
     OSReport("LOADCMD %x, %x, %x, %x\n", prog_entrypoint, prog_dst, prog_src, prog_len);


### PR DESCRIPTION
This update adds support for GCLoader

**Please note:** this is to be used in conjunction with a Game / Application loader like Swiss.

When installing Swiss **do not use** the GCLoader ISO. Instead use cubeboot as your boot.iso and grab the most recent `swiss_rXXXX.dol` from `swiss/DOL/` and rename that to `autoexec.dol` or `boot.dol` on the root of your SD card.

That this version changes boot order and fixes some bugs with SD cards (you may be able to disable fallback mode).

The order that cubeboot will search for devices now is: GCLoader, SD SD2SP2, SDGecko Slot B, SD Gecko Slot A