### PR TITLE
Fix GCLoader support, broken due to double-init of GCODE

### DIFF
--- a/cubeboot/source/sd.c
+++ b/cubeboot/source/sd.c
@@ -68,7 +68,7 @@ static int check_available_devices() {
         }
 
         iprintf("Trying mount %s\n", dev_name);
-        if (i < MAX_DRIVE)
+        if (driver->ioType == DEVICE_TYPE_GC_SD)
             sdgecko_setSpeed(i, EXI_SPEED32MHZ);
 
         if (driver->startup() && driver->isInserted()) {


### PR DESCRIPTION
Commit f499333 introduced a call to `GCODE_Init()` in an effort to accelerate the boot device detection loop.  Unfortunately, this function is called a second time inside driver->startup(), which seems to break loading files from GCLoader.  In this change, we restructure the boot device detection loop to avoid the double-init of GCODE.

This change also tries to reduce the fragility of the loop by calling `sdgecko_setSpeed()` based on device type rather than index in the list.