### PR TITLE
Add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.DS_Store
 __pycache__
 build/
 dist/**


### PR DESCRIPTION
`.DS_Store` is another common file to include in `.gitignore`, so seems worth including here.