### PR TITLE
Bump `actions/upload-artifact` in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           mv ./cubeboot/cubeboot.dol dist/next/cubeboot.dol
           # mv ./PicoBoot/picoboot.uf2 dist/next/cubeboot.uf2
       - name: Archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/next/


### PR DESCRIPTION
v3 appears to be deprecated, so let’s see if switching to v4 makes this repo’s GitHub Actions run successfully again.

Cc: @trevor403