### PR TITLE
Respect `disable_mcp_select` when playing discs

### DIFF
--- a/patches/source/gameid.c
+++ b/patches/source/gameid.c
@@ -20,6 +20,8 @@ void mcp_set_gameid(gm_file_entry_t *entry) {
 }
 
 void setup_gameid_commands(struct gcm_disk_info *di, char diskName[64]) {
+    if (disable_mcp_select) return;
+
     const s32 chan = 0;
     u32 id;
     s32 ret;


### PR DESCRIPTION
Due to the MemCard Pro code running slightly differently, when playing a disc with enhanced passthrough, the MemCard Pro would always be provided with the game’s title ID (and switch to a bespoke card), irrespective of the `disable_mcp_select` setting.

This adds an additional check to ensure that that setting is definitely adhered to.