### PR TITLE
Add option to display menu in widescreen

### DIFF
--- a/cubeboot/source/main.c
+++ b/cubeboot/source/main.c
@@ -301,6 +301,7 @@ int main(int argc, char **argv) {
     set_patch_value(symshdr, syment, symstringdata, "start_passthrough_game", force_passthrough);
     set_patch_value(symshdr, syment, symstringdata, "cube_color", settings.cube_color);
     set_patch_value(symshdr, syment, symstringdata, "force_progressive", settings.progressive_enabled);
+    set_patch_value(symshdr, syment, symstringdata, "force_widescreen", settings.force_widescreen);
     set_patch_value(symshdr, syment, symstringdata, "force_swiss_boot", settings.force_swiss_default);
 
     set_patch_value(symshdr, syment, symstringdata, "disable_mcp_select", settings.disable_mcp_select);

--- a/cubeboot/source/settings.c
+++ b/cubeboot/source/settings.c
@@ -95,6 +95,15 @@ void load_settings() {
         settings.progressive_enabled = progressive_enabled;
     }
 
+    // Force widescreen
+    u32 force_widescreen = 0;
+    if (!ini_sget(conf, "cubeboot", "force_widescreen", "%d", &force_widescreen)) {
+        settings.force_widescreen = 0;
+    } else {
+        iprintf("Found force_widescreen = %d\n", force_widescreen);
+        settings.force_widescreen = force_widescreen;
+    }
+
     // preboot delay
     u32 preboot_delay_ms = 0;
     if (!ini_sget(conf, "cubeboot", "preboot_delay_ms", "%u", &preboot_delay_ms)) {

--- a/cubeboot/source/settings.h
+++ b/cubeboot/source/settings.h
@@ -9,6 +9,7 @@ typedef struct settings {
     u32 show_watermark;
     u32 disable_mcp_select;
     u32 progressive_enabled;
+    u32 force_widescreen;
     u32 preboot_delay_ms;
     u32 postboot_delay_ms;
     char *default_program;

--- a/patches/linker/link_ntsc10.ld
+++ b/patches/linker/link_ntsc10.ld
@@ -40,6 +40,7 @@ ntsc10_draw_named_tex = 0x8130a460;
 ntsc10_get_camera_mtx = 0x813030ac;
 ntsc10_set_obj_pos = 0x81305494;
 ntsc10_set_obj_cam = 0x813054e0;
+ntsc10_projection_parameters = 0x8145dce0;
 ntsc10_fast_sin = 0x81307de8;
 ntsc10_fast_cos = 0x81307e04;
 ntsc10_apply_save_rot = 0x81307628;

--- a/patches/linker/link_ntsc11.ld
+++ b/patches/linker/link_ntsc11.ld
@@ -64,6 +64,7 @@ ntsc11_game_blob_text = 0x814b25c8;
 ntsc11_get_camera_mtx = 0x81302f94;
 ntsc11_set_obj_pos = 0x8130537c;
 ntsc11_set_obj_cam = 0x813053c8;
+ntsc11_projection_parameters = 0x81481ca0;
 
 ntsc11_fast_sin = 0x81307cd0;
 ntsc11_fast_cos = 0x81307cec;

--- a/patches/linker/link_ntsc12_001.ld
+++ b/patches/linker/link_ntsc12_001.ld
@@ -35,6 +35,7 @@ ntsc12_001_draw_named_tex = 0x8130a6e0;
 ntsc12_001_get_camera_mtx = 0x81303324;
 ntsc12_001_set_obj_pos = 0x81305718;
 ntsc12_001_set_obj_cam = 0x81305764;
+ntsc12_001_projection_parameters = 0x81482680;
 
 ntsc12_001___pformatter = 0x8137a1d0;
 ntsc12_001___StringWrite = 0x8137a164;

--- a/patches/linker/link_ntsc12_101.ld
+++ b/patches/linker/link_ntsc12_101.ld
@@ -35,6 +35,7 @@ ntsc12_101_draw_named_tex = 0x8130a6f8;
 ntsc12_101_get_camera_mtx = 0x8130333c;
 ntsc12_101_set_obj_pos = 0x81305730;
 ntsc12_101_set_obj_cam = 0x8130577c;
+ntsc12_101_projection_parameters = 0x81482b00;
 
 ntsc12_101___pformatter = 0x8137a654;
 ntsc12_101___StringWrite = 0x8137a5e8;

--- a/patches/linker/link_pal10.ld
+++ b/patches/linker/link_pal10.ld
@@ -35,6 +35,7 @@ pal10_draw_named_tex = 0x8130a284;
 pal10_get_camera_mtx = 0x81302f88;
 pal10_set_obj_pos = 0x8130537c;
 pal10_set_obj_cam = 0x813053c8;
+pal10_projection_parameters = 0x814adb40;
 
 pal10_Jac_StopSoundAll = 0x8135abe0;
 pal10_InitializeUART = 0x81363f00;

--- a/patches/linker/link_pal11.ld
+++ b/patches/linker/link_pal11.ld
@@ -35,6 +35,7 @@ pal11_draw_named_tex = 0x8130a36c;
 pal11_get_camera_mtx = 0x81302f88;
 pal11_set_obj_pos = 0x8130537c;
 pal11_set_obj_cam = 0x813053c8;
+pal11_projection_parameters = 0x8147c960;
 
 pal11___pformatter = 0x81378c18;
 pal11___StringWrite = 0x81378b54;

--- a/patches/linker/link_pal12.ld
+++ b/patches/linker/link_pal12.ld
@@ -35,6 +35,7 @@ pal12_draw_named_tex = 0x8130a3c4;
 pal12_get_camera_mtx = 0x813030f0;
 pal12_set_obj_pos = 0x813054e4;
 pal12_set_obj_cam = 0x81305530;
+pal12_projection_parameters = 0x814ae700;
 
 pal12___gx = 0x80000000;
 pal12___pformatter = 0x8137d9cc;

--- a/patches/source/main.c
+++ b/patches/source/main.c
@@ -46,6 +46,7 @@ __attribute_data__ u32 start_passthrough_game = 0;
 __attribute_data__ static u8 *cube_text_tex = NULL;
 __attribute_data__ char cube_logo_path[MAX_FILE_NAME] = {0};
 __attribute_data__ u32 force_progressive = 0;
+__attribute_data__ u32 force_widescreen = 0;
 __attribute_data__ u32 force_swiss_boot = 0;
 
 // used if we are switching to 60Hz on a PAL IPL
@@ -82,6 +83,23 @@ __attribute_data__ static GXColorS10 color_bg_outer_1;
 // start
 __attribute_data__ gm_file_entry_t boot_entry;
 __attribute_data__ gm_file_entry_t second_boot_entry;
+
+// These are technically floating-point constants that happen to be laid out together,
+// but they're laid out together in all IPL versions
+typedef struct {
+    struct {
+        float aspect_ratio;
+    } perspective;
+
+    struct {
+        float top;
+        float bottom;
+        float left;
+        float right;
+    } orthographic;
+} projection_parameters_t;
+
+__attribute_reloc__ projection_parameters_t *projection_parameters;
 
 __attribute_used__ void mod_cube_colors() {
     if (cube_color == 0) {
@@ -419,6 +437,18 @@ __attribute_used__ void pre_main() {
         rmode->vfilter[4] = 21;
         rmode->vfilter[5] = 0;
         rmode->vfilter[6] = 0;
+    }
+
+    if (force_widescreen) {
+        // In all IPL versions, the default projection matrices use:
+        // - a perspective aspect ratio of 1.3214285
+        // - an orthographic screen size of (t: 224, b: -224, l: -296, r: 292)
+        // (Note that the perspective and orthographic aspect ratios don't seem to match up, and neither are actually 4:3)
+        // We'll stretch these by the same ratio as 4:3 -> 16:9, and round the left/right values to integers
+        const float stretch = 4.0f / 3.0f;
+        projection_parameters->perspective.aspect_ratio = 1.3214285f * stretch;
+        projection_parameters->orthographic.left = floorf(-296.0f * stretch);
+        projection_parameters->orthographic.right = floorf(292.0f * stretch);
     }
 
     main();


### PR DESCRIPTION
When the `force_widescreen` option is enabled, this adjusts the parameters used for the perspective and orthographic projection matrices, so that the image is centred within an anamorphic 16:9 frame.

Note that this does reduce the effective horizontal resolution. This option is disabled by default.