### PR TITLE
Track the game IDs of moved/copied saves

### DIFF
--- a/patches/linker/link_ntsc10.ld
+++ b/patches/linker/link_ntsc10.ld
@@ -87,6 +87,7 @@ ntsc10___CARDGetStatusEx = 0x81347cc8;
 ntsc10_get_card_info = 0x8131b85c;
 ntsc10_draw_card_info = 0x8131a5b4;
 ntsc10_card_thread_mq = 0x81467790;
+ntsc10_read_save_banner_text = 0x8131c330;
 
 ntsc10_SetEffectivePriority = 0x813385e4;
 ntsc10___OSGetEffectivePriority = 0x813385a8;

--- a/patches/linker/link_ntsc11.ld
+++ b/patches/linker/link_ntsc11.ld
@@ -87,6 +87,7 @@ ntsc11___CARDGetStatusEx = 0x8136fafc;
 ntsc11_get_card_info = 0x8131bf88;
 ntsc11_draw_card_info = 0x8131abc0;
 ntsc11_card_thread_mq = 0x8148bfb0;
+ntsc11_read_save_banner_text = 0x8131ca5c;
 
 ntsc11_SetEffectivePriority = 0x8135f3e4;
 ntsc11___OSGetEffectivePriority = 0x8135f3a8;

--- a/patches/linker/link_ntsc12_001.ld
+++ b/patches/linker/link_ntsc12_001.ld
@@ -82,6 +82,7 @@ ntsc12_001___CARDGetStatusEx = 0x8135d110;
 ntsc12_001_get_card_info = 0x8131c320;
 ntsc12_001_draw_card_info = 0x8131af58;
 ntsc12_001_card_thread_mq = 0x8148d590;
+ntsc12_001_read_save_banner_text = 0x8131cdf4;
 
 ntsc12_001_SetEffectivePriority = 0x81362304;
 ntsc12_001___OSGetEffectivePriority = 0x813622c8;

--- a/patches/linker/link_ntsc12_101.ld
+++ b/patches/linker/link_ntsc12_101.ld
@@ -82,6 +82,7 @@ ntsc12_101___CARDGetStatusEx = 0x8135d110;
 ntsc12_101_get_card_info = 0x8131c338;
 ntsc12_101_draw_card_info = 0x8131af70;
 ntsc12_101_card_thread_mq = 0x8148da30;
+ntsc12_101_read_save_banner_text = 0x8131ce0c;
 
 ntsc12_101_SetEffectivePriority = 0x81362468;
 ntsc12_101___OSGetEffectivePriority = 0x8136242c;

--- a/patches/linker/link_pal10.ld
+++ b/patches/linker/link_pal10.ld
@@ -84,6 +84,7 @@ pal10___CARDGetStatusEx = 0x813730dc;
 pal10_get_card_info = 0x8131c934;
 pal10_draw_card_info = 0x8131b56c;
 pal10_card_thread_mq = 0x814b7eb0;
+pal10_read_save_banner_text = 0x8131d408;
 
 pal10_SetEffectivePriority = 0x813629c4;
 pal10___OSGetEffectivePriority = 0x81362988;

--- a/patches/linker/link_pal11.ld
+++ b/patches/linker/link_pal11.ld
@@ -82,6 +82,7 @@ pal11___CARDGetStatusEx = 0x8136fa1c;
 pal11_get_card_info = 0x8131beb4;
 pal11_draw_card_info = 0x8131aaec;
 pal11_card_thread_mq = 0x81486c70;
+pal11_read_save_banner_text = 0x8131c988;
 
 pal11_SetEffectivePriority = 0x8135f304;
 pal11___OSGetEffectivePriority = 0x8135f2c8;

--- a/patches/linker/link_pal12.ld
+++ b/patches/linker/link_pal12.ld
@@ -83,6 +83,7 @@ pal12___CARDGetStatusEx = 0x81360490;
 pal12_get_card_info = 0x8131ca74;
 pal12_draw_card_info = 0x8131b6ac;
 pal12_card_thread_mq = 0x814b9670;
+pal12_read_save_banner_text = 0x8131d548;
 
 pal12_SetEffectivePriority = 0x813657e0;
 pal12___OSGetEffectivePriority = 0x813657e0;

--- a/patches/source/memcard.c
+++ b/patches/source/memcard.c
@@ -30,13 +30,14 @@ typedef struct CARDDir {
 } CARDDir;
 
 __attribute_reloc__ s32 (*__CARDGetStatusEx)(s32 chan, s32 fileNo, CARDDir* dirent);
+__attribute_reloc__ s32 (*read_save_banner_text)(s32 chan, s32 fileNo, CARDDir *dirent, void *unknown);
 __attribute_reloc__ char* (*get_card_info)(s32 chan, s32 fileNo);
 __attribute_reloc__ void (*draw_card_info)(char unk);
 
 __attribute_data__ gameid_t card_game_ids[2][CARD_MAX_FILE];
-__attribute_used__ s32 save_card_status(s32 chan, s32 fileNo, CARDDir* dirent) {
-    s32 ret = __CARDGetStatusEx(chan, fileNo, dirent);
-    if (ret == 0) {
+__attribute_used__ s32 read_save_banner_text_and_game_id(s32 chan, s32 fileNo, CARDDir *dirent, void *unknown) {
+    s32 ret = read_save_banner_text(chan, fileNo, dirent, unknown);
+    if (ret >= 0) {
         gameid_t *id = &card_game_ids[chan][fileNo];
         memcpy(id, &dirent->gameName[0], sizeof(gameid_t));
     }

--- a/patches/source/patch.s
+++ b/patches/source/patch.s
@@ -26,8 +26,8 @@ patch_inst vNTSC_10(_fix_banner_bnr2) 0x81302778 nop
 patch_inst_ntsc "_patch_font_init" 0x81301240 0x8130107c 0x81301430 0x81301434 bl setup_fonts
 patch_inst_pal "_patch_font_init" 0x8130107c 0x8130107c 0x813011e8 bl setup_fonts
 
-patch_inst_ntsc "_patch_card_status_a" 0x8131c770 0x8131ce9c 0x8131d234 0x8131d24c bl save_card_status
-patch_inst_pal "_patch_card_status_a" 0x8131d848 0x8131cdc8 0x8131d988 bl save_card_status
+patch_inst_ntsc "_patch_read_save_banner_text" 0x8131c4e4 0x8131cc10 0x8131cfa8 0x8131cfc0 bl read_save_banner_text_and_game_id
+patch_inst_pal "_patch_read_save_banner_text" 0x8131d5bc 0x8131cb3c 0x8131d6fc bl read_save_banner_text_and_game_id
 
 patch_inst_ntsc "_patch_card_info_a" 0x8131a694 0x8131aca0 0x8131b038 0x8131b050 bl patched_card_info
 patch_inst_pal "_patch_card_info_a" 0x8131b64c 0x8131abcc 0x8131b78c bl patched_card_info


### PR DESCRIPTION
Rather than patching the code that populates the contents of a memory card, this patches a function that’s run (to populate the banner text, textures, etc.) whenever a save file is read, copied, or moved.

This ensures that the game IDs are always kept up-to-date, ensuring that the correct language is used even for newly copied/moved saves.