### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: devkitpro/devkitppc:20250727
+    container: ghcr.io/extremscorner/libogc2:20251109
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -14,14 +14,6 @@ jobs:
           . ./venv/bin/activate
           pip install --upgrade pip
           pip install -r patches/scripts/requirements.txt
-      - name: Build libogc2
-        run: |
-          git clone https://github.com/extremscorner/libogc2.git
-          (cd libogc2; make install)
-      - name: Build libfat
-        run: |
-          git clone https://github.com/extremscorner/libfat.git
-          (cd libfat; sed -i '/rice/d' Makefile; make ogc-install)
       - name: Build cubeboot
         run: |
           . ./venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,17 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: devkitpro/devkitppc:20231110
+    container: devkitpro/devkitppc:20250727
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup
         run: |
-          apt-get update && apt-get install -y genisoimage git golang nodejs build-essential gcc-arm-none-eabi python3-distutils python3-setuptools
-          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py
-          pip3 install -r patches/scripts/requirements.txt
+          apt-get update && apt-get install -y genisoimage git golang nodejs build-essential gcc-arm-none-eabi python3-venv python3-distutils python3-setuptools
+          python3 -m venv venv
+          . ./venv/bin/activate
+          pip install --upgrade pip
+          pip install -r patches/scripts/requirements.txt
       - name: Build libogc2
         run: |
           git clone https://github.com/extremscorner/libogc2.git
@@ -21,7 +23,9 @@ jobs:
           git clone https://github.com/extremscorner/libfat.git
           (cd libfat; sed -i '/rice/d' Makefile; make ogc-install)
       - name: Build cubeboot
-        run: cd entry; make clean && make
+        run: |
+          . ./venv/bin/activate
+          cd entry; make clean && make
       # - name: Build apploader
       #   run: |
       #     git clone -b force-early-boot --single-branch https://github.com/OffBroadway/gc-boot-tools.git
@@ -46,7 +50,7 @@ jobs:
           mv ./cubeboot/cubeboot.dol dist/next/cubeboot.dol
           # mv ./PicoBoot/picoboot.uf2 dist/next/cubeboot.uf2
       - name: Archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/next/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         run: |
-          apt-get update && apt-get install -y genisoimage git golang nodejs build-essential gcc-arm-none-eabi python3-venv python3-distutils python3-setuptools
-          python3 -m venv venv
-          . ./venv/bin/activate
-          pip install --upgrade pip
-          pip install -r patches/scripts/requirements.txt
+          apt-get update && apt-get install -y genisoimage git golang nodejs build-essential gcc-arm-none-eabi python3-pyelftools
       - name: Build cubeboot
-        run: |
-          . ./venv/bin/activate
-          cd entry; make clean && make
+        run: cd entry; make clean && make
       # - name: Build apploader
       #   run: |
       #     git clone -b force-early-boot --single-branch https://github.com/OffBroadway/gc-boot-tools.git


### PR DESCRIPTION
- Bump `actions/checkout` and `actions/upload-artifact` to `v4`
- Replace `devkitpro/devkitppc` with `extremscorner/libogc2` meaning that libogc2 and libfat don't need to be compiled because they are included in the container
- Install pyelftools using system package manager so a python virtual environment isn't needed

A successful run: https://github.com/wins1ey/contrib-cubiboot/actions/runs/19214530051