### PR TITLE
Add default_folder config setting

### DIFF
--- a/cubeboot/source/main.c
+++ b/cubeboot/source/main.c
@@ -315,6 +315,11 @@ int main(int argc, char **argv) {
     //     iprintf("Copying cube_logo_path: %p\n", cube_logo_ptr);
     //     strcpy(cube_logo_ptr, settings.cube_logo);
     // }
+    void *default_folder_ptr = (void*)get_symbol_value(symshdr, syment, symstringdata, "default_folder");
+    if (default_folder_ptr != NULL && settings.default_folder != NULL) {
+        iprintf("Copying default_folder: %p\n", default_folder_ptr);
+        strcpy(default_folder_ptr, settings.default_folder);
+    }
 
     // Copy other variables
     set_patch_value(symshdr, syment, symstringdata, "is_running_dolphin", is_running_dolphin);

--- a/cubeboot/source/settings.c
+++ b/cubeboot/source/settings.c
@@ -70,6 +70,13 @@ void load_settings() {
         settings.cube_logo = (char*)cube_logo;
     }
 
+    // default folder
+    const char *default_folder = ini_get(conf, "cubeboot", "default_folder");
+    if (default_folder != NULL) {
+        iprintf("Found default_folder = %s\n", default_folder);
+        settings.default_folder = (char*)default_folder;
+    }
+
     // default program
     const char *default_program = ini_get(conf, "cubeboot", "default_program");
     if (default_program != NULL) {

--- a/cubeboot/source/settings.h
+++ b/cubeboot/source/settings.h
@@ -5,6 +5,7 @@
 typedef struct settings {
     u32 cube_color;
     char *cube_logo;
+    char *default_folder;
     u32 force_swiss_default;
     u32 show_watermark;
     u32 disable_mcp_select;

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -5,5 +5,6 @@ These are all of the values supported by the `cubeboot.ini` file.
 ```
 cube_color = 00ffff     # hex color code
 cube_logo = path.png    # path to a 352x40px PNG image
+default_folder = /path/to/folder  # default folder to open
 force_progressive = 1   # enables progressive scan
 ```

--- a/patches/source/main.c
+++ b/patches/source/main.c
@@ -45,6 +45,7 @@ __attribute_data__ u32 start_passthrough_game = 0;
 
 __attribute_data__ static u8 *cube_text_tex = NULL;
 __attribute_data__ char cube_logo_path[MAX_FILE_NAME] = {0};
+__attribute_data__ char default_folder[MAX_FILE_NAME] = {0};
 __attribute_data__ u32 force_progressive = 0;
 __attribute_data__ u32 force_swiss_boot = 0;
 
@@ -347,6 +348,29 @@ __attribute_used__ void mod_cube_anim() {
     }
 }
 
+__attribute_used__ char* resolve_default_folder() {
+    if (default_folder[0] == '\0') {
+        OSReport("No default folder set, opening root\n");
+        return "/";
+    }
+
+    const char *path = default_folder;
+    static char path_buf[MAX_FILE_NAME];
+    if (default_folder[0] != '/') {
+        snprintf(path_buf, sizeof(path_buf), "/%s", default_folder);
+        path = path_buf;
+    }
+
+    if (dvd_custom_open(path, FILE_ENTRY_TYPE_DIR, 0) != 0) {
+        OSReport("Could not open default folder: %s, opening root\n", path);
+        return "/";
+    }
+    dvd_custom_close(dvd_custom_status()->fd);
+
+    OSReport("Using default folder: %s\n", path);
+    return path;
+}
+
 __attribute_used__ void pre_thread_init() {
     dolphin_ARAMInit();
     orig_thread_init();
@@ -354,7 +378,7 @@ __attribute_used__ void pre_thread_init() {
     gm_init_heap();
     gm_init_thread();
     if (!start_passthrough_game) {
-        gm_start_thread("/");
+        gm_start_thread(resolve_default_folder());
     }
 }
 


### PR DESCRIPTION
Set the default folder in cubeboot.ini with the key `default_folder`.
Example:
```ini
default_folder = games
```
Cubeboot will start with that folder open instead of `/`.

All of these opened the games folder on boot correctly:
```ini
default_folder = games
default_folder = games/
default_folder = /games
default_folder = /games/
```

Recreated this PR upstream here from https://github.com/makeo/cubiboot/pull/2